### PR TITLE
Support certificate pinning by other applications

### DIFF
--- a/USBHelperLauncher/Proxy.cs
+++ b/USBHelperLauncher/Proxy.cs
@@ -58,7 +58,18 @@ namespace USBHelperLauncher
 
         private void FiddlerApplication_BeforeRequest(Session oS)
         {
-            if (oS.HTTPMethodIs("CONNECT")) { oS.oFlags["X-ReplyWithTunnel"] = "Fake for HTTPS Tunnel"; return; }
+            if (oS.HTTPMethodIs("CONNECT"))
+            {
+                if(oS.hostname.EndsWith("wiiuusbhelper.com"))
+                {
+                    oS.oFlags["X-ReplyWithTunnel"] = "Fake for HTTPS Tunnel";
+                }
+                else
+                {
+                    oS.oFlags["x-no-decrypt"] = "Passthrough for non-relevant hosts";
+                }
+                return;
+            }
             if (oS.HostnameIs("cdn.wiiuusbhelper.com"))
             {
                 string path = oS.PathAndQuery;


### PR DESCRIPTION
Some applications that use certificate pinning (Dropbox, Mail, etc.) won't work while the proxy is running, since the generated root cert is ignored by those applications.

This disables FiddlerCore's SSL decryption for all hosts not related to wiiuusbhelper.com, which allows these applications to work normally again.
(See [https://www.fiddlerbook.com/Fiddler/help/httpsdecryption.asp#byhost](https://www.fiddlerbook.com/Fiddler/help/httpsdecryption.asp#byhost))