### PR TITLE
Fix issues with 3DS TMD downloads

### DIFF
--- a/USBHelperLauncher/Net/Proxy.cs
+++ b/USBHelperLauncher/Net/Proxy.cs
@@ -27,7 +27,8 @@ namespace USBHelperLauncher.Net
             new ContentEndpoint(),
             new ApplicationEndpoint(),
             new RegistrationEndpoint(),
-            new SiteEndpoint()
+            new SiteEndpoint(),
+            new WiiUShopEndpoint()
         };
 
         private ushort port;
@@ -59,7 +60,7 @@ namespace USBHelperLauncher.Net
         {
             if (oS.HTTPMethodIs("CONNECT"))
             {
-                if(oS.hostname.EndsWith("wiiuusbhelper.com"))
+                if (oS.hostname.EndsWith("wiiuusbhelper.com"))
                 {
                     oS.oFlags["X-ReplyWithTunnel"] = "Fake for HTTPS Tunnel";
                 }

--- a/USBHelperLauncher/Net/Proxy.cs
+++ b/USBHelperLauncher/Net/Proxy.cs
@@ -41,6 +41,7 @@ namespace USBHelperLauncher.Net
             FiddlerApplication.Log.OnLogString += Log_OnLogString;
             FiddlerApplication.BeforeRequest += FiddlerApplication_BeforeRequest;
             FiddlerApplication.AfterSessionComplete += FiddlerApplication_AfterSessionComplete;
+            FiddlerApplication.ResponseHeadersAvailable += FiddlerApplication_ResponseHeadersAvailable;
         }
 
         public void Start()
@@ -140,6 +141,22 @@ namespace USBHelperLauncher.Net
         private void Log_OnLogString(object sender, LogEventArgs e)
         {
             log.WriteLine(e.LogString);
+        }
+
+        private void FiddlerApplication_ResponseHeadersAvailable(Session oS)
+        {
+            if (oS.oResponse.headers.Exists("Content-Length"))
+            {
+                if (long.TryParse(oS.oResponse["Content-Length"], out long len))
+                {
+                    // Don't cache responses > 50MB
+                    if (len > 50 * 1024 * 1024)
+                    {
+                        oS.bBufferResponse = false;
+                        oS["log-drop-response-body"] = "save memory";
+                    }
+                }
+            }
         }
 
         public static void LogRequest(Session oS, Endpoint endpoint, string message)

--- a/USBHelperLauncher/Net/WiiUShopEndpoint.cs
+++ b/USBHelperLauncher/Net/WiiUShopEndpoint.cs
@@ -1,0 +1,26 @@
+﻿using Fiddler;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace USBHelperLauncher.Net
+{
+    class WiiUShopEndpoint : Endpoint
+    {
+        public WiiUShopEndpoint() : base("ccs.cdn.wup.shop.nintendo.net") { }
+
+        protected WiiUShopEndpoint(string hostName) : base(hostName) { }
+
+        [Request("/*")]
+        public void Get(Session oS)
+        {
+            oS.utilCreateResponseAndBypassServer();
+            oS.oResponse.headers.SetStatus(307, "Redirect");
+            oS.oResponse["Location"] = "http://ccs.cdn.c.shop.nintendowifi.net" + oS.PathAndQuery;
+            Proxy.LogRequest(oS, this, "Redirecting to http://ccs.cdn.c.shop.nintendowifi.net" + oS.PathAndQuery);
+        }
+    }
+}

--- a/USBHelperLauncher/USBHelperLauncher.csproj
+++ b/USBHelperLauncher/USBHelperLauncher.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Emulator\ZipPackage.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="ModuleInitInjector.cs" />
+    <Compile Include="Net\WiiUShopEndpoint.cs" />
     <Compile Include="Net\SiteEndpoint.cs" />
     <Compile Include="ProgressDialog.cs">
       <SubType>Form</SubType>


### PR DESCRIPTION
Fixes 404 errors caused by a change at Nintendo's servers that prevents downloads of 3DS TMDs (and content files) from the WiiU shop subdomain.