### PR TITLE
Fix download speed chart alignment

### DIFF
--- a/USBHelperInjector/Patches/SpeedChartPatch.cs
+++ b/USBHelperInjector/Patches/SpeedChartPatch.cs
@@ -1,0 +1,39 @@
+﻿using Harmony;
+using System.Collections;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
+namespace USBHelperInjector.Patches
+{
+    [HarmonyPatch]
+    internal class SpeedChartPatch
+    {
+        static MethodBase TargetMethod()
+        {
+            return (from method in ReflectionHelper.NusGrabberForm.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                    where method.ReturnType == typeof(void) && method.GetParameters().Length == 0
+                    && method.GetMethodBody().LocalVariables.Count == 1 && method.GetMethodBody().LocalVariables[0].LocalType == typeof(System.TimeSpan)
+                    select method).FirstOrDefault();
+        }
+
+        static void Postfix(object __instance)
+        {
+            FieldInfo speedChartField = (from field in __instance.GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
+                                         where field.FieldType == Assembly.Load("LiveCharts.Winforms").GetType("LiveCharts.WinForms.CartesianChart")
+                                         select field).FirstOrDefault();
+
+            var speedChart = speedChartField.GetValue(__instance);
+
+            // enable animations for grid
+            IList axisXCollection = (IList)AccessTools.Property(speedChart.GetType(), "AxisX").GetValue(speedChart);
+            var axis = axisXCollection[axisXCollection.Count - 1];
+            AccessTools.Property(axis.GetType(), "DisableAnimations").SetValue(axis, false);
+
+            // set step size
+            var axisSeparator = AccessTools.Property(axis.GetType(), "Separator").GetValue(axis);
+            var stepValue = AccessTools.Property(axisSeparator.GetType(), "Step").GetValue(axisSeparator);
+            AccessTools.Property(axis.GetType(), "Unit").SetValue(axis, stepValue);
+        }
+    }
+}

--- a/USBHelperInjector/USBHelperInjector.csproj
+++ b/USBHelperInjector/USBHelperInjector.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Patches\ServicePointPatch.cs" />
     <Compile Include="Patches\SettingsDonationKeyPatches.cs" />
     <Compile Include="Patches\SettingsProxyPatches.cs" />
+    <Compile Include="Patches\SpeedChartPatch.cs" />
     <Compile Include="Pipes\Packets\ActionPacket.cs" />
     <Compile Include="Pipes\Packets\CertificateAuthorityPacket.cs" />
     <Compile Include="Pipes\DataStream.cs" />


### PR DESCRIPTION
Fixes alignment issues and enables animations for the gridlines of Wii U USB Helper's download speed chart.