### PR TITLE
Add request handling for '/requestZipHash.php' and '/hash_zip/*'

### DIFF
--- a/USBHelperLauncher/Net/ApplicationEndpoint.cs
+++ b/USBHelperLauncher/Net/ApplicationEndpoint.cs
@@ -55,5 +55,22 @@ namespace USBHelperLauncher.Net
             oS.responseBodyBytes = dataBytes;
             Proxy.LogRequest(oS, this, "Created zip from " + url);
         }
+
+        [Request("/requestZipHash.php")]
+        [Request("/hash_zip/*")]
+        public void GetZipHash(Session oS)
+        {
+            string data = Path.GetFileName(oS.PathAndQuery);
+            if (data == "requestZipHash.php")
+            {
+                data = GetRequestData(oS).Get("url");
+            }
+
+            byte[] bytes = Convert.FromBase64String(data);
+            string url = Encoding.UTF8.GetString(bytes);
+
+            oS.utilCreateResponseAndBypassServer();
+            Proxy.LogRequest(oS, this, "Sent empty zip hash for " + url);
+        }
     }
 }

--- a/USBHelperLauncher/Net/Endpoint.cs
+++ b/USBHelperLauncher/Net/Endpoint.cs
@@ -25,10 +25,9 @@ namespace USBHelperLauncher.Net
 
         public bool Handle(Session oS)
         {
-            Request request = null;
             foreach (var method in GetType().GetMethods())
             {
-                if ((request = method.GetCustomAttributes().OfType<Request>().FirstOrDefault()) != null && request.Matches(oS))
+                if (method.GetCustomAttributes().OfType<Request>().Any(request => request.Matches(oS)))
                 {
                     method.Invoke(this, new object[] { oS });
                     return true;

--- a/USBHelperLauncher/Net/Request.cs
+++ b/USBHelperLauncher/Net/Request.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace USBHelperLauncher.Net
 {
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     class Request : Attribute
     {
         private string mask;


### PR DESCRIPTION
- Fix an issue that may occur when Wii U USB Helper sends a request to `/requestZipHash.php` or `/hash_zip/*` on the application endpoint, as it will throw an exception in some cases where a 4xx reponse was received
- Allow the `Request` method attribute to be applied to the same method multiple times