### PR TITLE
Add Antivirus Programs to debug message

### DIFF
--- a/USBHelperLauncher/USBHelperLauncher.csproj
+++ b/USBHelperLauncher/USBHelperLauncher.csproj
@@ -74,6 +74,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Management" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />


### PR DESCRIPTION
Add a new line to the debug messages containing information about antivirus types/programs (retrieved through WMI) for easier support/debugging.