### PR TITLE
 Use application region instead of date/time region for title descriptions (fixes #22)

### DIFF
--- a/USBHelperInjector/Patches/LanguagePatch.cs
+++ b/USBHelperInjector/Patches/LanguagePatch.cs
@@ -1,0 +1,41 @@
+﻿using Harmony;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace USBHelperInjector.Patches
+{
+    [Optional]
+    [HarmonyPatch]
+    class LanguagePatch
+    {
+        static MethodBase TargetMethod()
+        {
+            // v0.6.1.655: GClass32.Class43.method_0
+            return (from type in ReflectionHelper.Types
+                    where type.GetProperty("Dlc", BindingFlags.Public | BindingFlags.Instance) != null
+                    from nested in type.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Instance)
+                    where nested.GetFields(BindingFlags.Public | BindingFlags.Instance).Any(p => p.FieldType == type)
+                    from method in nested.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                    select method).FirstOrDefault();
+        }
+
+        static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+
+            var cultureGetter = typeof(CultureInfo).GetProperty("CurrentCulture").GetGetMethod();
+            var uiCultureGetter = typeof(CultureInfo).GetProperty("CurrentUICulture").GetGetMethod();
+
+            var index = codes.FindIndex(i => i.opcode == OpCodes.Call && ((MethodBase)i.operand) == cultureGetter);
+            if (index != -1)
+            {
+                codes[index].operand = uiCultureGetter;
+            }
+
+            return codes;
+        }
+    }
+}

--- a/USBHelperInjector/USBHelperInjector.csproj
+++ b/USBHelperInjector/USBHelperInjector.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Patches\KeySiteFormValidationPatch.cs" />
     <Compile Include="Patches\KeySite3DSSettingsPatch.cs" />
     <Compile Include="Patches\KeySiteErrorMessagePatch.cs" />
+    <Compile Include="Patches\LanguagePatch.cs" />
     <Compile Include="Patches\MessageBoxPatch.cs" />
     <Compile Include="Patches\SearchPatch.cs" />
     <Compile Include="Patches\ServicePointPatch.cs" />


### PR DESCRIPTION
Currently the program uses the date/time regional format for determining the language for title descriptions (see #22). This PR patches the corresponding method to use the application region instead.