### PR TITLE
Fix custom HTTP proxy + auth (fixes #40)

### DIFF
--- a/USBHelperInjector/Contracts/ILauncherService.cs
+++ b/USBHelperInjector/Contracts/ILauncherService.cs
@@ -10,6 +10,9 @@ namespace USBHelperInjector.Contracts
         void SetKeySite(string site, string url);
 
         [OperationContract]
+        string SetCustomProxy(string address, string username, string password);
+
+        [OperationContract]
         void SendInjectorSettings();
     }
 }

--- a/USBHelperInjector/InjectorService.cs
+++ b/USBHelperInjector/InjectorService.cs
@@ -45,6 +45,26 @@ namespace USBHelperInjector
                     }
                 }
             });
+
+            Overrides.OnSetProxy += OnSetProxy;
+        }
+
+        private static void OnSetProxy(WebProxy proxy)
+        {
+            string address = null, username = null, password = null;
+            if (proxy != null)
+            {
+                var credentials = (NetworkCredential)proxy.Credentials;
+                address = proxy.Address.OriginalString;
+                username = credentials.UserName;
+                password = credentials.Password;
+            }
+
+            string error = LauncherService.SetCustomProxy(address, username, password);
+            if (error != null)
+            {
+                throw new Exception(error);
+            }
         }
 
         public void ForceKeySiteForm()

--- a/USBHelperInjector/Patches/CustomProxyPatch.cs
+++ b/USBHelperInjector/Patches/CustomProxyPatch.cs
@@ -1,0 +1,63 @@
+﻿using Harmony;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace USBHelperInjector.Patches
+{
+    [Optional]
+    [HarmonyPatch]
+    class CustomProxyPatch
+    {
+        static MethodBase TargetMethod()
+        {
+            // v0.6.1.655: NusGrabberForm.cmdSetProxy_Click
+            return (from method in ReflectionHelper.NusGrabberForm.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                    where method.ReturnType == typeof(void) && method.GetParameters().Length == 2
+                    && method.GetMethodBody().LocalVariables.Any(l => l.LocalType == typeof(NetworkCredential))
+                    select method).FirstOrDefault();
+        }
+
+        static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+
+            // Fix password field
+            int indexLdFldPassword = codes.FindIndex(i => i.opcode == OpCodes.Newobj && ((MethodBase)i.operand) == typeof(NetworkCredential).GetConstructor(new[] { typeof(string), typeof(string) }));
+            indexLdFldPassword = codes.FindLastIndex(indexLdFldPassword, i => i.opcode == OpCodes.Ldfld);
+            codes[indexLdFldPassword] = new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(CustomProxyPatch), "GetPasswordBox"));
+
+            // Fix credentials
+            int indexDefaultCredentials = codes.FindIndex(i => i.opcode == OpCodes.Callvirt && ((MethodBase)i.operand) == typeof(WebProxy).GetProperty("UseDefaultCredentials").GetSetMethod());
+            codes[indexDefaultCredentials] = new CodeInstruction(OpCodes.Pop);
+
+
+            // Remove proxy availability check
+            int indexWebRequestCreate = codes.FindIndex(i => i.opcode == OpCodes.Call && ((MethodInfo)i.operand) == typeof(WebRequest).GetMethod("Create", new[] { typeof(string) }));
+            indexWebRequestCreate = codes.FindLastIndex(indexWebRequestCreate, i => i.opcode == OpCodes.Ldc_I4);
+            int indexEndFinally = codes.FindIndex(i => i.opcode == OpCodes.Endfinally);
+
+            int indexSetProxyEnd = codes.FindIndex(i => i.opcode == OpCodes.Call && ((MethodBase)i.operand) == SettingsProxySet.TargetMethod());
+            int indexSetProxyStart = codes.FindLastIndex(indexSetProxyEnd, i => i.opcode == OpCodes.Ldarg_0);
+
+            var setProxyInstructions = codes.GetRange(indexSetProxyStart, indexSetProxyEnd - indexSetProxyStart + 1);
+            setProxyInstructions[0].blocks.Clear();
+
+            codes.RemoveRange(indexWebRequestCreate, indexEndFinally - indexWebRequestCreate + 1);
+            codes.InsertRange(indexWebRequestCreate, setProxyInstructions);
+
+            return codes;
+        }
+
+        private static object GetPasswordBox(object instance)
+        {
+            return (from field in instance.GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
+                    where field.FieldType.FullName == "Telerik.WinControls.UI.RadTextBox"
+                    let value = field.GetValue(instance)
+                    where (string)value.GetType().GetProperty("Name").GetValue(value) == "radTextBox1"
+                    select value).FirstOrDefault();
+        }
+    }
+}

--- a/USBHelperInjector/Patches/SettingsProxyPatches.cs
+++ b/USBHelperInjector/Patches/SettingsProxyPatches.cs
@@ -7,7 +7,7 @@ namespace USBHelperInjector.Patches
     [HarmonyPatch]
     internal class SettingsProxyGet
     {
-        static MethodBase TargetMethod()
+        internal static MethodBase TargetMethod()
         {
             return AccessTools.DeclaredProperty(ReflectionHelper.NusGrabberForm, "Proxy").GetGetMethod(true);
         }
@@ -26,7 +26,7 @@ namespace USBHelperInjector.Patches
     [HarmonyPatch]
     internal class SettingsProxySet
     {
-        static MethodBase TargetMethod()
+        internal static MethodBase TargetMethod()
         {
             return AccessTools.DeclaredProperty(ReflectionHelper.NusGrabberForm, "Proxy").GetSetMethod(true);
         }

--- a/USBHelperInjector/USBHelperInjector.csproj
+++ b/USBHelperInjector/USBHelperInjector.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Optional.cs" />
     <Compile Include="Overrides.cs" />
     <Compile Include="Patches\Disable3DSDownload.cs" />
+    <Compile Include="Patches\CustomProxyPatch.cs" />
     <Compile Include="Patches\DlcTMDPatch.cs" />
     <Compile Include="Patches\DownloaderPatch.cs" />
     <Compile Include="Patches\DownloaderQueuePatch.cs" />

--- a/USBHelperLauncher/DebugMessage.cs
+++ b/USBHelperLauncher/DebugMessage.cs
@@ -37,6 +37,8 @@ namespace USBHelperLauncher
             sb.AppendLine("Session Length: " + (now - Program.GetSessionStart()).ToString(@"hh\:mm\:ss"));
             sb.AppendLine("Session GUID: " + Program.GetSessionGuid().ToString());
             sb.AppendLine("Proxy Available: " + (exception == null ? "Yes" : "No (" + exception.Message + ")"));
+            sb.Append("Custom Proxy: " + (Program.GetProxy().CustomProxyAddress != null ? Program.GetProxy().CustomProxyAddress : "<none>"));
+            sb.AppendLine(Program.GetProxy().CustomProxyAuthorization != null ? " (with authorization)" : "");
             sb.AppendLine("Version: " + Program.GetVersion());
             sb.AppendLine("Helper Version: " + Program.GetHelperVersion());
             sb.AppendLine(".NET Framework Version: " + Get45or451FromRegistry());

--- a/USBHelperLauncher/LauncherService.cs
+++ b/USBHelperLauncher/LauncherService.cs
@@ -1,5 +1,8 @@
 ﻿using Fiddler;
+using System;
+using System.Net;
 using System.ServiceModel;
+using System.Text;
 using USBHelperInjector.Contracts;
 using USBHelperLauncher.Configuration;
 
@@ -11,6 +14,61 @@ namespace USBHelperLauncher
         {
             Settings.TitleKeys[site] = url;
             Settings.Save();
+        }
+
+        public string SetCustomProxy(string address, string username, string password)
+        {
+            string authString = null;
+            if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+            {
+                authString = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:{1}", username, password)));
+            }
+
+            string error = null;
+            if (!string.IsNullOrEmpty(address))
+            {
+                int index = address.IndexOf("://");
+                if (index != -1)
+                {
+                    string originalAddress = address;
+                    string scheme = address.Substring(0, index);
+                    address = address.Substring(index + 3); // remove "<scheme>://" from address
+                    if (scheme.StartsWith("socks"))
+                    {
+                        address = "socks=" + address;
+                    }
+                    Program.GetLogger().WriteLine("Rewrote proxy address \"{0}\" to \"{1}\"", originalAddress, address);
+                }
+
+                HttpWebRequest request = (HttpWebRequest)WebRequest.Create("http://example.com");
+                request.Proxy = Program.GetProxy().GetWebProxy();
+                request.Timeout = 2000;
+                request.Method = "GET";
+                request.Headers["X-FiddlerCustomProxy"] = address;
+                request.Headers["Proxy-Authorization"] = authString;
+                try
+                {
+                    request.GetResponse();
+                }
+                catch (Exception e)
+                {
+                    error = e.Message;
+                }
+            }
+
+            Program.GetProxy().CustomProxyAddress = error == null ? address : null;
+            Program.GetProxy().CustomProxyAuthorization = error == null ? authString : null;
+
+            if (error == null)
+            {
+                Program.GetLogger().WriteLine("Set custom proxy to \"{0}\"", address);
+            }
+            else
+            {
+                Program.GetLogger().WriteLine("Could not set custom proxy to \"{0}\" (error: {1})", address, error);
+            }
+
+            return error;
         }
 
         public void SendInjectorSettings()

--- a/USBHelperLauncher/Net/Proxy.cs
+++ b/USBHelperLauncher/Net/Proxy.cs
@@ -34,6 +34,9 @@ namespace USBHelperLauncher.Net
         private readonly TextWriter log;
         private readonly Buffer<Session> sessions;
 
+        public string CustomProxyAddress;
+        public string CustomProxyAuthorization;
+
         public Proxy(ushort port)
         {
             this.port = port;
@@ -61,6 +64,17 @@ namespace USBHelperLauncher.Net
 
         private void FiddlerApplication_BeforeRequest(Session oS)
         {
+            if (oS.RequestHeaders.Exists("X-FiddlerCustomProxy"))
+            {
+                oS["x-overrideGateway"] = oS.RequestHeaders["X-FiddlerCustomProxy"];
+                oS.RequestHeaders.Remove("X-FiddlerCustomProxy");
+            }
+            else
+            {
+                oS["x-overrideGateway"] = CustomProxyAddress;
+                oS.RequestHeaders["Proxy-Authorization"] = CustomProxyAuthorization;
+            }
+
             if (oS.HTTPMethodIs("CONNECT"))
             {
                 if (oS.hostname.EndsWith("wiiuusbhelper.com"))


### PR DESCRIPTION
Previously the custom proxy setting in USB Helper had no effect as the proxy would always be overwritten with the internal FiddlerCore proxy. This PR works around the issue by intercepting the proxy settings the user entered and using the proxy as an upstream proxy for FiddlerCore.
Additionally, socks proxies are also now supported as FiddlerCore, unlike WebProxy in  .NET, allows using a socks proxy as an upstream proxy.