### PR TITLE
Migrate to new domain for CDN fallback

### DIFF
--- a/USBHelperLauncher/Configuration/Settings.cs
+++ b/USBHelperLauncher/Configuration/Settings.cs
@@ -29,7 +29,7 @@ namespace USBHelperLauncher.Configuration
         [Setting("Launcher")]
         public static Dictionary<string, string> EndpointFallbacks { get; set; } = new Dictionary<string, string>()
         {
-            { typeof(ContentEndpoint).Name, "https://cdn.0x100.xyz/wiiuusbhelper/cdn/" }
+            { typeof(ContentEndpoint).Name, "https://cdn.shiftinv.cc/wiiuusbhelper/cdn/" }
         };
 
         [Setting("Launcher")]

--- a/USBHelperLauncher/Program.cs
+++ b/USBHelperLauncher/Program.cs
@@ -24,6 +24,7 @@ using System.Xml.Linq;
 using USBHelperInjector.Contracts;
 using USBHelperLauncher.Configuration;
 using USBHelperLauncher.Emulator;
+using USBHelperLauncher.Net;
 using USBHelperLauncher.Utils;
 
 namespace USBHelperLauncher
@@ -50,6 +51,7 @@ namespace USBHelperLauncher
         static void Main(string[] args)
         {
             Settings.Load();
+            MigrateSettings();
             Settings.Save();
             proxy = new Net.Proxy(8877);
             _handler += new EventHandler(Handler);
@@ -581,6 +583,17 @@ namespace USBHelperLauncher
             trayIcon.Dispose();
             logger.Dispose();
         }
+
+        private static void MigrateSettings()
+        {
+            // > 0.14d
+            if (Settings.EndpointFallbacks.TryGetValue(typeof(ContentEndpoint).Name, out var contentEndpointUrl)
+                && contentEndpointUrl == "https://cdn.0x100.xyz/wiiuusbhelper/cdn/")
+            {
+                Settings.EndpointFallbacks[typeof(ContentEndpoint).Name] = "https://cdn.shiftinv.cc/wiiuusbhelper/cdn/";
+            }
+        }
+
 
         public static string GenerateDonationKey()
         {


### PR DESCRIPTION
The old domain (cdn.0x100.xyz) will expire on 2020-10-06, depending on the traffic at that time I may extend it for another year. For now it'll be up for at least ~1.5 years, that should hopefully be enough time for everyone to update to at least once.