### PR TITLE
Replace font under certain conditions

### DIFF
--- a/USBHelperInjector/Patches/EasterEggFontPatch.cs
+++ b/USBHelperInjector/Patches/EasterEggFontPatch.cs
@@ -1,0 +1,42 @@
+﻿using Harmony;
+using System;
+using System.Drawing;
+using System.Reflection;
+using USBHelperInjector.Patches.Attributes;
+
+namespace USBHelperInjector.Patches
+{
+    [Optional]
+    [HarmonyPatch]
+    class EasterEggFontPatch
+    {
+        private static string fontName;
+
+        static EasterEggFontPatch()
+        {
+            if (DateTime.Now.Month == 4 && DateTime.Now.Day == 1)
+            {
+                // check if the font exists on the system
+                var name = "Comic Sans MS";
+                var font = new Font(name, 12);
+                if (font.Name == name)
+                {
+                    fontName = name;
+                }
+            }
+        }
+
+        static MethodBase TargetMethod()
+        {
+            return typeof(FontFamily).GetMethod("CreateFontFamily", BindingFlags.NonPublic | BindingFlags.Instance);
+        }
+
+        static void Prefix(ref object __0)
+        {
+            if (fontName != null)
+            {
+                __0 = fontName;
+            }
+        }
+    }
+}

--- a/USBHelperInjector/USBHelperInjector.csproj
+++ b/USBHelperInjector/USBHelperInjector.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Patches\DlcTMDPatch.cs" />
     <Compile Include="Patches\DownloaderPatch.cs" />
     <Compile Include="Patches\DownloaderQueuePatch.cs" />
+    <Compile Include="Patches\EasterEggFontPatch.cs" />
     <Compile Include="Patches\PortablePatches.cs" />
     <Compile Include="Patches\ForceKeySiteFormPatch.cs" />
     <Compile Include="Patches\KeySiteFormHideObsoletePatch.cs" />


### PR DESCRIPTION
This patch replaces all fonts with `Comic Sans MS` if the date is April 1st, as discussed previously. The patch is pretty simple, therefore it should work on all Windows versions; I've found no issues on Windows 7 or 10.