### PR TITLE
Enable enter key in titlekey form

### DIFF
--- a/USBHelperInjector/Patches/KeySiteFormEnterPatch.cs
+++ b/USBHelperInjector/Patches/KeySiteFormEnterPatch.cs
@@ -1,0 +1,33 @@
+﻿using Harmony;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Windows.Forms;
+using USBHelperInjector.Patches.Attributes;
+
+namespace USBHelperInjector.Patches
+{
+    [Optional]
+    [HarmonyPatch]
+    class KeySiteFormEnterPatch
+    {
+        internal static MethodBase TargetMethod()
+        {
+            return KeySiteFormHideObsoletePatch.TargetMethod();
+        }
+
+        internal static void Postfix(Form __instance)
+        {
+            var propEvents = typeof(Control).GetProperty("Events", BindingFlags.NonPublic | BindingFlags.Instance);
+            var eventClick = typeof(Control).GetField("EventClick", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+            var okButton = (from field in ReflectionHelper.FrmAskTicket.Type.GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                            where field.FieldType.Name == "RadButton"
+                            let button = (IButtonControl) field.GetValue(__instance)
+                            let lst = (EventHandlerList) propEvents.GetValue(button)
+                            let handler = lst[eventClick]
+                            where handler?.Method == ReflectionHelper.FrmAskTicket.OkButtonHandler
+                            select button).FirstOrDefault();
+            __instance.AcceptButton = okButton;
+        }
+    }
+}

--- a/USBHelperInjector/Patches/KeySiteFormHideObsoletePatch.cs
+++ b/USBHelperInjector/Patches/KeySiteFormHideObsoletePatch.cs
@@ -9,7 +9,7 @@ namespace USBHelperInjector.Patches
     [HarmonyPatch]
     class KeySiteFormHideObsoletePatch
     {
-        static MethodBase TargetMethod()
+        internal static MethodBase TargetMethod()
         {
             return (from method in ReflectionHelper.FrmAskTicket.Type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
                     where method.GetParameters().Count() == 0

--- a/USBHelperInjector/USBHelperInjector.csproj
+++ b/USBHelperInjector/USBHelperInjector.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Patches\SpeedChartPatch.cs" />
     <Compile Include="Contracts\IInjectorService.cs" />
     <Compile Include="Patches\SystemUpdateWarningPatch.cs" />
+    <Compile Include="Patches\KeySiteFormEnterPatch.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
This patch allows users to use the enter key instead of clicking the 'Ok' button in the titlekey form, which should also help with incorrectly sized textboxes caused by different DPI/scaling settings.