### PR TITLE
Use new update/DLC locations introduced in Cemu 1.15.11 (fixes #57)

### DIFF
--- a/USBHelperInjector/Patches/CemuPathPatches.cs
+++ b/USBHelperInjector/Patches/CemuPathPatches.cs
@@ -1,0 +1,83 @@
+﻿using HarmonyLib;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace USBHelperInjector.Patches
+{
+    [HarmonyPatch]
+    class CemuUpdatePathPatch
+    {
+        private static readonly object MOVE_LOCK = new object();
+
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.Property(ReflectionHelper.MainModule.GetType("NusHelper.Emulators.Cemu"), "UpdatePath").GetGetMethod();
+        }
+
+        static void Postfix(object __instance, ref string __result)
+        {
+            if (GetCemuVersion(__instance) >= new Version(1, 15, 11))
+            {
+                __result = TryRewriteAndMoveDirectory(__result, "0005000e");
+            }
+        }
+
+        internal static string TryRewriteAndMoveDirectory(string originalPath, string newTitleDirectory)
+        {
+            // rewrite path, remove "/aoc" suffix if it exists
+            var components = originalPath.Split(Path.DirectorySeparatorChar).ToList();
+            if (components.Last() == "aoc")
+            {
+                components.RemoveAt(components.Count - 1);
+            }
+            components[components.Count - 2] = newTitleDirectory;
+            var newPath = string.Join(Path.DirectorySeparatorChar.ToString(), components);
+
+            lock (MOVE_LOCK)
+            {
+                try
+                {
+                    if (Directory.Exists(originalPath) && !Directory.Exists(newPath))
+                    {
+                        Directory.CreateDirectory(Directory.GetParent(newPath).FullName);
+                        Directory.Move(originalPath, newPath);
+                    }
+                }
+                catch (Exception e)
+                {
+                    MessageBox.Show(string.Format("Unable to move directory \"{0}\" to \"{1}\":\n\n{2}", originalPath, newPath, e), "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+            }
+
+            return newPath;
+        }
+
+        internal static Version GetCemuVersion(object instance)
+        {
+            var executable = (string)AccessTools.Method(TargetMethod().DeclaringType, "GetExecutable").Invoke(instance, null);
+            var versionInfo = FileVersionInfo.GetVersionInfo(executable);
+            return new Version(versionInfo.ProductMajorPart, versionInfo.ProductMinorPart, versionInfo.ProductBuildPart, versionInfo.ProductPrivatePart);
+        }
+    }
+
+    [HarmonyPatch]
+    class CemuDlcPathPatch
+    {
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.Property(ReflectionHelper.MainModule.GetType("NusHelper.Emulators.Cemu"), "DlcPath").GetGetMethod();
+        }
+
+        static void Postfix(object __instance, ref string __result)
+        {
+            if (CemuUpdatePathPatch.GetCemuVersion(__instance) >= new Version(1, 15, 11))
+            {
+                __result = CemuUpdatePathPatch.TryRewriteAndMoveDirectory(__result, "0005000c");
+            }
+        }
+    }
+}

--- a/USBHelperInjector/USBHelperInjector.csproj
+++ b/USBHelperInjector/USBHelperInjector.csproj
@@ -56,6 +56,7 @@
     <Compile Include="InjectorService.cs" />
     <Compile Include="Patches\Attributes\Optional.cs" />
     <Compile Include="Overrides.cs" />
+    <Compile Include="Patches\CemuPathPatches.cs" />
     <Compile Include="Patches\Disable3DSDownload.cs" />
     <Compile Include="Patches\Attributes\VersionSpecific.cs" />
     <Compile Include="Patches\DisableWebTabPatch.cs" />


### PR DESCRIPTION
Cemu v1.15.11 introduced new paths for update/DLC files ([https://cemu.info/changelog/cemu_1_15_11.txt](https://cemu.info/changelog/cemu_1_15_11.txt)):
* Updates: `mlc01/.../00050000/<titleid[0:8]>`  ->  `mlc01/.../0005000e/<titleid[0:8]>`
* DLC: `mlc01/.../00050000/<titleid[0:8]>/aoc`  ->  `mlc01/.../0005000c/<titleid[0:8]>`

This PR patches `NusHelper.Emulators.Cemu.UpdatePath/.DlcPath` to return these paths and moves the directories from their previous locations to the new ones when using Cemu ≥ 1.15.11.

~~Edit: Do not merge yet, I just found another potential issue with the code that I can't fix right now.~~ Fixed.