### PR TITLE
Make Portable setting by default

### DIFF
--- a/USBHelperLauncher/Configuration/Settings.cs
+++ b/USBHelperLauncher/Configuration/Settings.cs
@@ -77,7 +77,7 @@ namespace USBHelperLauncher.Configuration
         [Setting("Injector", 1000)]
         public static int DelayBetweenRetries { get; set; }
 
-        [Setting("Injector", false)]
+        [Setting("Injector", true)]
         public static bool Portable { get; set; }
 
         [Setting("Injector", false)]


### PR DESCRIPTION
Don't see any reason to keep this disabled. Didn't cause any problems, and who wants trash in their appdata folder?