### PR TITLE
Add option to split manual unpack directories into games and updates+dlc

### DIFF
--- a/USBHelperInjector/Contracts/IInjectorService.cs
+++ b/USBHelperInjector/Contracts/IInjectorService.cs
@@ -49,5 +49,8 @@ namespace USBHelperInjector.Contracts
 
         [OperationContract]
         void SetEshopRegion(string eshopRegion);
+
+        [OperationContract]
+        void SetSplitUnpackDirectories(bool splitUnpackDirectories);
     }
 }

--- a/USBHelperInjector/InjectorService.cs
+++ b/USBHelperInjector/InjectorService.cs
@@ -23,6 +23,7 @@ namespace USBHelperInjector
         public static string[] DisableTabs { get; private set; }
         public static string LocaleFile { get; private set; }
         public static string EshopRegion { get; private set; }
+        public static bool SplitUnpackDirectories { get; private set; }
 
         public static void Init()
         {
@@ -123,6 +124,11 @@ namespace USBHelperInjector
         public void SetEshopRegion(string eshopRegion)
         {
             EshopRegion = eshopRegion;
+        }
+
+        public void SetSplitUnpackDirectories(bool splitUnpackDirectories)
+        {
+            SplitUnpackDirectories = splitUnpackDirectories;
         }
     }
 }

--- a/USBHelperInjector/Patches/Disable3DSDownload.cs
+++ b/USBHelperInjector/Patches/Disable3DSDownload.cs
@@ -54,7 +54,7 @@ namespace USBHelperInjector.Patches
         {
             return (from method in ReflectionHelper.NusGrabberForm.Type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
                     where method.GetParameters().Length == 1
-                    && method.GetParameters()[0].ParameterType.GetProperty("Dlc") != null
+                    && method.GetParameters()[0].ParameterType == ReflectionHelper.TitleTypes.Game
                     && method.GetMethodBody().LocalVariables.Count == 0
                     && !method.IsSpecialName
                     select method).FirstOrDefault();
@@ -75,7 +75,7 @@ namespace USBHelperInjector.Patches
         {
             return (from method in ReflectionHelper.NusGrabberForm.Type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
                     where method.GetParameters().Length == 1
-                    && method.GetParameters()[0].ParameterType.GetProperty("Dlc") != null
+                    && method.GetParameters()[0].ParameterType == ReflectionHelper.TitleTypes.Game
                     && method.GetMethodBody().LocalVariables.Count == 2
                     && method.GetMethodBody().LocalVariables.Any(info => info.LocalType == ReflectionHelper.MainModule.GetType("NusHelper.DataSize"))
                     select method).FirstOrDefault();

--- a/USBHelperInjector/Patches/LanguagePatch.cs
+++ b/USBHelperInjector/Patches/LanguagePatch.cs
@@ -14,10 +14,8 @@ namespace USBHelperInjector.Patches
         static MethodBase TargetMethod()
         {
             // v0.6.1.655: GClass32.Class43.method_0
-            return (from type in ReflectionHelper.Types
-                    where type.GetProperty("Dlc", BindingFlags.Public | BindingFlags.Instance) != null
-                    from nested in type.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Instance)
-                    where nested.GetFields(BindingFlags.Public | BindingFlags.Instance).Any(p => p.FieldType == type)
+            return (from nested in ReflectionHelper.TitleTypes.Game.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Instance)
+                    where nested.GetFields(BindingFlags.Public | BindingFlags.Instance).Any(p => p.FieldType == ReflectionHelper.TitleTypes.Game)
                     from method in nested.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
                     select method).FirstOrDefault();
         }

--- a/USBHelperInjector/Patches/UnpackDirectoryPatch.cs
+++ b/USBHelperInjector/Patches/UnpackDirectoryPatch.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using System.Linq;
+using HarmonyLib;
+using System.Reflection;
+using USBHelperInjector.Patches.Attributes;
+
+namespace USBHelperInjector.Patches
+{
+    [HarmonyPatch]
+    [Optional]
+    class UnpackDirectoryPatch
+    {
+        static bool Prepare()
+        {
+            return InjectorService.SplitUnpackDirectories;
+        }
+
+        static MethodBase TargetMethod()
+        {
+            // v0.6.1.655: GClass30.method_16
+            return (from method in ReflectionHelper.TitleTypes.Game.BaseType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                    where method.ReturnType == typeof(bool)
+                        && method.GetMethodBody().LocalVariables.Any(v => v.LocalType == typeof(DriveInfo))
+                    select method).FirstOrDefault();
+        }
+
+        static void Prefix(object __instance, ref string __0)
+        {
+            var unpackDir = new[] { ReflectionHelper.TitleTypes.Update, ReflectionHelper.TitleTypes.Dlc }.Contains(__instance.GetType())
+                ? "Updates and DLC"
+                : "Base Games";
+            __0 = Path.Combine(__0, unpackDir);
+        }
+    }
+}

--- a/USBHelperInjector/ReflectionHelper.cs
+++ b/USBHelperInjector/ReflectionHelper.cs
@@ -64,5 +64,25 @@ namespace USBHelperInjector
             );
             public static List<FieldInfo> TextBoxes => _textBoxes.Value;
         }
+
+        public static class TitleTypes
+        {
+            private static readonly Lazy<Type> _game = new Lazy<Type>(
+                () => (from type in Types
+                       where type.GetProperty("Dlc", BindingFlags.Public | BindingFlags.Instance) != null
+                       select type).FirstOrDefault()
+            );
+            public static Type Game => _game.Value;
+
+            private static readonly Lazy<Type> _update = new Lazy<Type>(
+                () => Game.GetProperty("Updates", BindingFlags.Public | BindingFlags.Instance).PropertyType.GenericTypeArguments[0]
+            );
+            public static Type Update => _update.Value;
+
+            private static readonly Lazy<Type> _dlc = new Lazy<Type>(
+                () => Game.GetProperty("Dlc", BindingFlags.Public | BindingFlags.Instance).PropertyType
+            );
+            public static Type Dlc => _dlc.Value;
+        }
     }
 }

--- a/USBHelperInjector/ReflectionHelper.cs
+++ b/USBHelperInjector/ReflectionHelper.cs
@@ -12,103 +12,57 @@ namespace USBHelperInjector
     {
         private static readonly Assembly assembly = Assembly.Load("WiiU_USB_Helper");
 
-        public static Type[] Types { get; } = assembly.GetTypes();
+        public static readonly Type[] Types = assembly.GetTypes();
 
-        public static Module MainModule { get; } = assembly.GetModule("WiiU_USB_Helper.exe");
+        public static readonly Module MainModule = assembly.GetModule("WiiU_USB_Helper.exe");
 
-        public static MethodInfo EntryPoint { get; } = assembly.EntryPoint;
+        public static readonly MethodInfo EntryPoint = assembly.EntryPoint;
 
-        public static Type Settings
-        {
-            get
-            {
-                return assembly.GetType("WIIU_Downloader.Properties.Settings");
-            }
-        }
+        public static readonly Type Settings = assembly.GetType("WIIU_Downloader.Properties.Settings");
 
         public static class NusGrabberForm
         {
-            private static Type _type;
-            public static Type Type
-            {
-                get
-                {
-                    if (_type == null)
-                    {
-                        _type = (from type in Types
-                                 where typeof(Form).IsAssignableFrom(type)
-                                 from prop in type.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance)
-                                 where prop.Name == "Proxy"
-                                 select type).FirstOrDefault();
-                    }
-                    return _type;
-                }
-            }
+            private static readonly Lazy<Type> _type = new Lazy<Type>(
+                () => (from type in Types
+                       where typeof(Form).IsAssignableFrom(type)
+                       from prop in type.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance)
+                       where prop.Name == "Proxy"
+                       select type).FirstOrDefault()
+            );
+            public static Type Type => _type.Value;
 
-            private static ConstructorInfo _constructor;
-            public static ConstructorInfo Constructor
-            {
-                get
-                {
-                    if (_constructor == null)
-                    {
-                        _constructor = Type.GetConstructor(Type.EmptyTypes);
-                    }
-                    return _constructor;
-                }
-            }
+            private static readonly Lazy<ConstructorInfo> _constructor = new Lazy<ConstructorInfo>(
+                () => Type.GetConstructor(Type.EmptyTypes)
+            );
+            public static ConstructorInfo Constructor => _constructor.Value;
         }
 
         public static class FrmAskTicket
         {
-            private static Type _type;
-            public static Type Type
-            {
-                get
-                {
-                    if (_type == null)
-                    {
-                        _type = (from type in Types
-                                 where type.GetProperty("FileLocationWiiU") != null
-                                 select type).FirstOrDefault();
-                    }
-                    return _type;
-                }
-            }
+            private static readonly Lazy<Type> _type = new Lazy<Type>(
+                () => (from type in Types
+                       where type.GetProperty("FileLocationWiiU") != null
+                       select type).FirstOrDefault()
+            );
+            public static Type Type => _type.Value;
 
-            private static MethodInfo _okButtonHandler;
-            public static MethodInfo OkButtonHandler
-            {
-                get
-                {
-                    if (_okButtonHandler == null)
-                    {
-                        _okButtonHandler = (from method in Type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                                            let instructions = PatchProcessor.GetOriginalInstructions(method, out _)
-                                            where instructions.Any(x => x.opcode == OpCodes.Call && ((MethodInfo)x.operand).Name == "set_FileLocation3DS")
-                                            && instructions.Any(x => x.opcode == OpCodes.Ldfld && ((FieldInfo)x.operand).FieldType.Name == "RadTextBox")
-                                            select method).FirstOrDefault();
-                    }
-                    return _okButtonHandler;
-                }
-            }
+            private static readonly Lazy<MethodInfo> _okButtonHandler = new Lazy<MethodInfo>(
+                () => (from method in Type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                       let instructions = PatchProcessor.GetOriginalInstructions(method, out _)
+                       where instructions.Any(x => x.opcode == OpCodes.Call && ((MethodInfo)x.operand).Name == "set_FileLocation3DS")
+                          && instructions.Any(x => x.opcode == OpCodes.Ldfld && ((FieldInfo)x.operand).FieldType.Name == "RadTextBox")
+                       select method).FirstOrDefault()
+            );
+            public static MethodInfo OkButtonHandler => _okButtonHandler.Value;
 
-            private static List<FieldInfo> _textBoxes;
-            public static List<FieldInfo> TextBoxes
-            {
-                get
-                {
-                    if (_textBoxes == null)
-                    {
-                        _textBoxes = (from instruction in PatchProcessor.GetOriginalInstructions(OkButtonHandler, out _)
-                                      where instruction.opcode == OpCodes.Ldfld
-                                      let field = (FieldInfo)instruction.operand
-                                      where field.FieldType.Name == "RadTextBox"
-                                      select field).ToList();
-                    }
-                    return _textBoxes;
-                }
-            }
+            private static readonly Lazy<List<FieldInfo>> _textBoxes = new Lazy<List<FieldInfo>>(
+                () => (from instruction in PatchProcessor.GetOriginalInstructions(OkButtonHandler, out _)
+                       where instruction.opcode == OpCodes.Ldfld
+                       let field = (FieldInfo)instruction.operand
+                       where field.FieldType.Name == "RadTextBox"
+                       select field).ToList()
+            );
+            public static List<FieldInfo> TextBoxes => _textBoxes.Value;
         }
     }
 }

--- a/USBHelperInjector/USBHelperInjector.csproj
+++ b/USBHelperInjector/USBHelperInjector.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Patches\StringLocalizationPatch.cs" />
     <Compile Include="Patches\SystemUpdateWarningPatch.cs" />
     <Compile Include="Patches\KeySiteFormEnterPatch.cs" />
+    <Compile Include="Patches\UnpackDirectoryPatch.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/USBHelperLauncher/Configuration/Settings.cs
+++ b/USBHelperLauncher/Configuration/Settings.cs
@@ -89,6 +89,9 @@ namespace USBHelperLauncher.Configuration
         [Setting("Injector", false)]
         public static bool NoFunAllowed { get; set; }
 
+        [Setting("Injector", true)]
+        public static bool SplitUnpackDirectories { get; set; }
+
         public static void Save()
         {
             DoNotModify = Program.GetVersion();

--- a/USBHelperLauncher/LauncherService.cs
+++ b/USBHelperLauncher/LauncherService.cs
@@ -39,6 +39,7 @@ namespace USBHelperLauncher
             channel.SetPortable(Settings.Portable);
             channel.SetForceHttp(Settings.ForceHttp);
             channel.SetFunAllowed(!Settings.NoFunAllowed);
+            channel.SetSplitUnpackDirectories(Settings.SplitUnpackDirectories);
         }
     }
 }


### PR DESCRIPTION
Changes:
- Add option for unpacking updates + DLC into a folder separate from the game unpack folder
- Add `ReflectionHelper.TitleTypes.Game`/`.Update`/`.Dlc`, corresponding to the game/update/DLC classes (`GClass32`/`GClass33`/`GClass31` in v0.6.1.655) respectively
- Use `Lazy<T>` properties instead of manually caching values in `ReflectionHelper`

As far as I'm aware no functionality depends on the default hierarchy of the unpack directory, so changing it shouldn't cause any issues.