### PR TITLE
Fix issues in Wine

### DIFF
--- a/USBHelperInjector/IPC/IInjectorService.cs
+++ b/USBHelperInjector/IPC/IInjectorService.cs
@@ -52,5 +52,8 @@ namespace USBHelperInjector.IPC
 
         [OperationContract]
         void SetSplitUnpackDirectories(bool splitUnpackDirectories);
+
+        [OperationContract]
+        void SetWineCompat(bool wineCompat);
     }
 }

--- a/USBHelperInjector/Patches/Attributes/WineOnly.cs
+++ b/USBHelperInjector/Patches/Attributes/WineOnly.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace USBHelperInjector.Patches.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    class WineOnly : Attribute
+    {
+        public static bool IsWineOnly(Type type)
+        {
+            return GetCustomAttribute(type, typeof(WineOnly)) != null;
+        }
+    }
+}

--- a/USBHelperInjector/Patches/Disable3DSDownload.cs
+++ b/USBHelperInjector/Patches/Disable3DSDownload.cs
@@ -73,12 +73,7 @@ namespace USBHelperInjector.Patches
     {
         static MethodBase TargetMethod()
         {
-            return (from method in ReflectionHelper.NusGrabberForm.Type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
-                    where method.GetParameters().Length == 1
-                    && method.GetParameters()[0].ParameterType == ReflectionHelper.TitleTypes.Game
-                    && method.GetMethodBody().LocalVariables.Count == 2
-                    && method.GetMethodBody().LocalVariables.Any(info => info.LocalType == ReflectionHelper.MainModule.GetType("NusHelper.DataSize"))
-                    select method).FirstOrDefault();
+            return ReflectionHelper.NusGrabberForm.Methods.PlayGame;
         }
 
         static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions, ILGenerator generator)

--- a/USBHelperInjector/Patches/WineCompatibilityPatches.cs
+++ b/USBHelperInjector/Patches/WineCompatibilityPatches.cs
@@ -1,0 +1,44 @@
+﻿using System.Reflection;
+using System.Windows.Forms;
+using HarmonyLib;
+using USBHelperInjector.Patches.Attributes;
+
+namespace USBHelperInjector.Patches
+{
+    [WineOnly]
+    [HarmonyPatch]
+    class WineDisableDownloadManagerOverlay
+    {
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.DeclaredProperty(ReflectionHelper.Settings, "ShowDownloadManagerTip").GetGetMethod(true);
+        }
+
+        static bool Prefix(ref bool __result)
+        {
+            __result = false;
+            return false;
+        }
+    }
+
+    [WineOnly]
+    [HarmonyPatch]
+    class WineDisablePlayGame
+    {
+        static MethodBase TargetMethod()
+        {
+            return ReflectionHelper.NusGrabberForm.Methods.PlayGame;
+        }
+
+        static bool Prefix()
+        {
+            MessageBox.Show(
+                "Starting games directly from USB Helper is not supported in Wine",
+                "Error",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
+            return false;
+        }
+    }
+}

--- a/USBHelperInjector/ReflectionHelper.cs
+++ b/USBHelperInjector/ReflectionHelper.cs
@@ -35,6 +35,20 @@ namespace USBHelperInjector
                 () => Type.GetConstructor(Type.EmptyTypes)
             );
             public static ConstructorInfo Constructor => _constructor.Value;
+
+            public static class Methods
+            {
+                private static readonly Lazy<MethodBase> _playGame = new Lazy<MethodBase>(
+                    () => (from method in NusGrabberForm.Type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                           where method.GetParameters().Length == 1
+                              && method.GetParameters()[0].ParameterType == ReflectionHelper.TitleTypes.Game
+                              && method.GetMethodBody().LocalVariables.Count == 2
+                              && method.GetMethodBody().LocalVariables.Any(info => info.LocalType == ReflectionHelper.MainModule.GetType("NusHelper.DataSize"))
+                           select method).FirstOrDefault()
+                );
+
+                public static MethodBase PlayGame => _playGame.Value;
+            }
         }
 
         public static class FrmAskTicket

--- a/USBHelperInjector/USBHelperInjector.csproj
+++ b/USBHelperInjector/USBHelperInjector.csproj
@@ -42,6 +42,7 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -65,6 +66,7 @@
     <Compile Include="ModuleInitInjectedAttribute.cs" />
     <Compile Include="Patches\Attributes\Optional.cs" />
     <Compile Include="Overrides.cs" />
+    <Compile Include="Patches\Attributes\WineOnly.cs" />
     <Compile Include="Patches\CemuPathPatches.cs" />
     <Compile Include="Patches\CommandLineArgsPatch.cs" />
     <Compile Include="Patches\Disable3DSDownload.cs" />
@@ -98,6 +100,7 @@
     <Compile Include="Patches\SystemUpdateWarningPatch.cs" />
     <Compile Include="Patches\KeySiteFormEnterPatch.cs" />
     <Compile Include="Patches\UnpackDirectoryPatch.cs" />
+    <Compile Include="Patches\WineCompatibilityPatches.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/USBHelperLauncher/DebugMessage.cs
+++ b/USBHelperLauncher/DebugMessage.cs
@@ -14,6 +14,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using USBHelperLauncher.Configuration;
+using USBHelperLauncher.Utils;
 
 namespace USBHelperLauncher
 {
@@ -51,6 +52,8 @@ namespace USBHelperLauncher
             sb.AppendLine("System Language: " + CultureInfo.CurrentUICulture.Name);
             sb.AppendLine("Total Memory: " + info.TotalPhysicalMemory);
             sb.AppendLine("Available Memory: " + info.AvailablePhysicalMemory);
+            sb.AppendLine("Command-line Arguments: " + string.Join(" ", Environment.GetCommandLineArgs().Skip(1)));
+            if (WineUtil.IsRunningInWine()) sb.AppendLine("Wine version: " + WineUtil.TryGetVersion());
             TryCatch(() => GetAntiVirus(ref av), e => sb.AppendLine("Antivirus Software: Error (" + e.Message + ")"));
             AppendDictionary(sb, "Antivirus Software", av.ToDictionary(x => x.Key, x => x.Value ? "Enabled" : "Disabled"));
             AppendDictionary(sb, "Hosts", hosts.GetHosts().ToDictionary(x => x, x => hosts.Get(x).ToString()));

--- a/USBHelperLauncher/LauncherService.cs
+++ b/USBHelperLauncher/LauncherService.cs
@@ -41,6 +41,7 @@ namespace USBHelperLauncher
             channel.SetForceHttp(Settings.ForceHttp);
             channel.SetFunAllowed(!Settings.NoFunAllowed);
             channel.SetSplitUnpackDirectories(Settings.SplitUnpackDirectories);
+            channel.SetWineCompat(Program.WineCompat);
         }
     }
 }

--- a/USBHelperLauncher/Net/Proxy.cs
+++ b/USBHelperLauncher/Net/Proxy.cs
@@ -52,6 +52,13 @@ namespace USBHelperLauncher.Net
             sessions = new Buffer<Session>(Settings.SessionBufferSize);
             FiddlerApplication.OnValidateServerCertificate += (sender, args) =>
             {
+                if (Program.WineCompat)
+                {
+                    // required, as WineCompat sets ForceHttp = true and invalid certificates significantly impact performance in Wine
+                    args.ValidityState = CertificateValidity.ForceValid;
+                    return;
+                }
+
                 var errors = args.CertificatePolicyErrors;
 
                 // No need to re-verify

--- a/USBHelperLauncher/Program.cs
+++ b/USBHelperLauncher/Program.cs
@@ -45,6 +45,7 @@ namespace USBHelperLauncher
         public static DateTime SessionStart { get; private set; }
         public static string PublicKey { get; private set; }
         public static bool OverridePublicKey { get; private set; } = true;
+        public static bool WineCompat { get; private set; } = false;
 
         [STAThread]
         static void Main(string[] args)
@@ -71,6 +72,9 @@ namespace USBHelperLauncher
                             Settings.Portable = true;
                             Settings.Save();
                             break;
+                        case "wine":
+                            WineCompat = true;
+                            break;
                     }
                 }
             }
@@ -78,6 +82,24 @@ namespace USBHelperLauncher
             Logger.WriteLine("Made by FailedShack");
             SetConsoleVisibility(showConsole);
             Application.EnableVisualStyles();
+
+            if (!WineCompat && WineUtil.IsRunningInWine())
+            {
+                var result = MessageBox.Show(
+                    "Detected Wine environment.\nWould you like to enable settings/patches to improve Wine compatibility?\n(To enable this by default, run USBHelperLauncher with the \"--wine\" flag)",
+                    "Question",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Question
+                );
+                WineCompat = result == DialogResult.Yes;
+            }
+            if (WineCompat)
+            {
+                Logger.WriteLine("Wine compatibility settings enabled");
+                Settings.ForceHttp = true;
+                Settings.IPCType = IPCType.TCP;
+                Settings.Save();
+            }
 
             if (Settings.ShowUpdateNag)
             {

--- a/USBHelperLauncher/USBHelperLauncher.csproj
+++ b/USBHelperLauncher/USBHelperLauncher.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Utils\IOUtil.cs" />
     <Compile Include="Utils\RedirectRequest.cs" />
     <Compile Include="Utils\SourceforgeUtil.cs" />
+    <Compile Include="Utils\WineUtil.cs" />
     <Compile Include="Utils\WinUtil.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/USBHelperLauncher/Utils/WineUtil.cs
+++ b/USBHelperLauncher/Utils/WineUtil.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.InteropServices;
+
+namespace USBHelperLauncher.Utils
+{
+    static class WineUtil
+    {
+        // see: https://wiki.winehq.org/Developer_FAQ#How_can_I_detect_Wine.3F
+        [DllImport("ntdll.dll")]
+        [return: MarshalAs(UnmanagedType.LPStr)]
+        private static extern string wine_get_version();
+
+        public static string TryGetVersion()
+        {
+            try
+            {
+                return wine_get_version();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static bool IsRunningInWine() => TryGetVersion() != null;
+    }
+}


### PR DESCRIPTION
This fixes the most common issues when running USB Helper in Wine by patching a few things and setting some default values.
Wine is detected by checking if `ntdll` exports `wine_get_version`; Wine compatibility mode can also be enabled manually by passing `--wine` to the launcher.

Changes:
- Set `ForceHttp = true` and `IPCType = IPCType.TCP` by default
- Disable the download manager hint overlay and the "Play Game" feature
- Set the WPF render mode to `SoftwareOnly`, which fixes a crash related to the speed graph
- Accept all HTTPS certificates in FiddlerCore regardless of trust, which is required as invalid certificates seem to cause high CPU usage

`wine-staging` is recommended, as it's currently significantly faster than `wine-stable`.

I've also created a docker image based on Ubuntu 18.04 + wine-staging + .NET 4.8 [here][1], which can run USB Helper using this + #68 and display it over a local VNC connection.

(These changes depend on TCP IPC bindings, included in #68)

[1]: https://github.com/shiftinv/docker-usbhelper