### PR TITLE
Fix unpack directory split patch

### DIFF
--- a/USBHelperInjector/Patches/Disable3DSDownload.cs
+++ b/USBHelperInjector/Patches/Disable3DSDownload.cs
@@ -14,7 +14,7 @@ namespace USBHelperInjector.Patches
     {
         internal static MethodBase TargetMethod()
         {
-            var shwGetter = ReflectionHelper.Settings.GetProperty("ShowHaxchiWarning").GetGetMethod();
+            var shwGetter = ReflectionHelper.Settings.Type.GetProperty("ShowHaxchiWarning").GetGetMethod();
             return (from method in ReflectionHelper.NusGrabberForm.Type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
                     where method.GetParameters().Length == 1
                     && method.GetParameters()[0].ParameterType.IsAbstract

--- a/USBHelperInjector/Patches/DownloadManagerOverlayPatch.cs
+++ b/USBHelperInjector/Patches/DownloadManagerOverlayPatch.cs
@@ -12,7 +12,7 @@ namespace USBHelperInjector.Patches
     {
         static MethodBase TargetMethod()
         {
-            return AccessTools.DeclaredProperty(ReflectionHelper.Settings, "ShowDownloadManagerTip").GetGetMethod(true);
+            return AccessTools.DeclaredProperty(ReflectionHelper.Settings.Type, "ShowDownloadManagerTip").GetGetMethod(true);
         }
 
         static bool Prefix(ref bool __result)

--- a/USBHelperInjector/Patches/ForceKeySiteFormPatch.cs
+++ b/USBHelperInjector/Patches/ForceKeySiteFormPatch.cs
@@ -8,7 +8,7 @@ namespace USBHelperInjector.Patches
     {
         static MethodBase TargetMethod()
         {
-            return AccessTools.DeclaredProperty(ReflectionHelper.Settings, "TicketsPath").GetGetMethod(true);
+            return AccessTools.DeclaredProperty(ReflectionHelper.Settings.Type, "TicketsPath").GetGetMethod(true);
         }
 
         static bool Prefix(ref string __result)

--- a/USBHelperInjector/Patches/InvalidConfigPatch.cs
+++ b/USBHelperInjector/Patches/InvalidConfigPatch.cs
@@ -15,7 +15,7 @@ namespace USBHelperInjector.Patches
     {
         static MethodBase TargetMethod()
         {
-            return ReflectionHelper.Settings.GetConstructor(Type.EmptyTypes);
+            return ReflectionHelper.Settings.Type.GetConstructor(Type.EmptyTypes);
         }
 
         static void Postfix()

--- a/USBHelperInjector/Patches/KeySite3DSSettingsPatch.cs
+++ b/USBHelperInjector/Patches/KeySite3DSSettingsPatch.cs
@@ -8,12 +8,12 @@ namespace USBHelperInjector.Patches
     {
         static MethodBase TargetMethod()
         {
-            return AccessTools.DeclaredProperty(ReflectionHelper.Settings, "TicketsPath3DS").GetGetMethod(true);
+            return AccessTools.DeclaredProperty(ReflectionHelper.Settings.Type, "TicketsPath3DS").GetGetMethod(true);
         }
 
         static bool Prefix(object __instance, ref string __result)
         {
-            var hasWiiUTitleKeys = !string.IsNullOrEmpty((string) AccessTools.DeclaredProperty(ReflectionHelper.Settings, "TicketsPath").GetValue(__instance));
+            var hasWiiUTitleKeys = !string.IsNullOrEmpty(ReflectionHelper.Settings.GetValue<string>("TicketsPath", __instance));
             __result = hasWiiUTitleKeys ? "http://3ds.titlekeys.gq/" : string.Empty;
             return false;
         }

--- a/USBHelperInjector/Patches/SettingsDonationKeyPatches.cs
+++ b/USBHelperInjector/Patches/SettingsDonationKeyPatches.cs
@@ -8,7 +8,7 @@ namespace USBHelperInjector.Patches
     {
         static MethodBase TargetMethod()
         {
-            return AccessTools.DeclaredProperty(ReflectionHelper.Settings, "DonationKey").GetGetMethod(true);
+            return AccessTools.DeclaredProperty(ReflectionHelper.Settings.Type, "DonationKey").GetGetMethod(true);
         }
 
         static bool Prefix(ref string __result)
@@ -27,7 +27,7 @@ namespace USBHelperInjector.Patches
     {
         static MethodBase TargetMethod()
         {
-            return AccessTools.DeclaredProperty(ReflectionHelper.Settings, "DonationKey").GetSetMethod(true);
+            return AccessTools.DeclaredProperty(ReflectionHelper.Settings.Type, "DonationKey").GetSetMethod(true);
         }
 
         static bool Prefix(ref string value)

--- a/USBHelperInjector/Patches/SystemUpdateWarningPatch.cs
+++ b/USBHelperInjector/Patches/SystemUpdateWarningPatch.cs
@@ -8,7 +8,7 @@ namespace USBHelperInjector.Patches
     {
         static MethodBase TargetMethod()
         {
-            return AccessTools.DeclaredProperty(ReflectionHelper.Settings, "Show552Warning").GetGetMethod(true);
+            return AccessTools.DeclaredProperty(ReflectionHelper.Settings.Type, "Show552Warning").GetGetMethod(true);
         }
 
         static bool Prefix(ref bool __result)

--- a/USBHelperInjector/Patches/UnpackDirectoryPatch.cs
+++ b/USBHelperInjector/Patches/UnpackDirectoryPatch.cs
@@ -26,6 +26,11 @@ namespace USBHelperInjector.Patches
 
         static void Prefix(object __instance, ref string __0)
         {
+            // only modify paths to the configured unpack directory, not for builtin emulators
+            if (__0 != ReflectionHelper.Settings.GetValue<string>("ExtractFolder"))
+            {
+                return;
+            }
             var unpackDir = new[] { ReflectionHelper.TitleTypes.Update, ReflectionHelper.TitleTypes.Dlc }.Contains(__instance.GetType())
                 ? "Updates and DLC"
                 : "Base Games";

--- a/USBHelperInjector/Patches/WineCompatibilityPatches.cs
+++ b/USBHelperInjector/Patches/WineCompatibilityPatches.cs
@@ -11,7 +11,7 @@ namespace USBHelperInjector.Patches
     {
         static MethodBase TargetMethod()
         {
-            return AccessTools.DeclaredProperty(ReflectionHelper.Settings, "ShowDownloadManagerTip").GetGetMethod(true);
+            return AccessTools.DeclaredProperty(ReflectionHelper.Settings.Type, "ShowDownloadManagerTip").GetGetMethod(true);
         }
 
         static bool Prefix(ref bool __result)

--- a/USBHelperInjector/ReflectionHelper.cs
+++ b/USBHelperInjector/ReflectionHelper.cs
@@ -18,7 +18,26 @@ namespace USBHelperInjector
 
         public static readonly MethodInfo EntryPoint = assembly.EntryPoint;
 
-        public static readonly Type Settings = assembly.GetType("WIIU_Downloader.Properties.Settings");
+        public static class Settings
+        {
+            public static readonly Type Type = assembly.GetType("WIIU_Downloader.Properties.Settings");
+
+            private static readonly Lazy<object> _default = new Lazy<object>(
+                () => Type.GetProperty("Default").GetValue(null)
+            );
+            public static object Default => _default.Value;
+
+
+            public static T GetValue<T>(string name, object instance = null)
+            {
+                return (T)Type.GetProperty(name).GetValue(instance ?? Default);
+            }
+
+            public static void SetValue<T>(string name, T value, object instance = null)
+            {
+                Type.GetProperty(name).SetValue(instance ?? Default, value);
+            }
+        }
 
         public static class NusGrabberForm
         {


### PR DESCRIPTION
The patch in commit 74aa959561588d8cb3c3fdca9edd9a03adabb645 split unpacked data into separate directories *unconditionally*. This would cause issues with builtin emulators, as the patch would also be applied to their extraction paths (i.e. for the `Prepare for Emulation` feature), messing up the expected directory hierarchy.  
This fix ensures that the target directories are only patched if the extraction target is the configured `ExtractFolder`, and not an emulator path.